### PR TITLE
Change Upload URL for Shelter

### DIFF
--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -70,7 +70,6 @@ jobs:
           url: https://ingest.codecov.io
           files: coverage.xml
           flags: common
-          url: 
 
   test-py27:
     name: common, python 2.7, ubuntu-20.04

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -67,8 +67,10 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: common
+          url: 
 
   test-py27:
     name: common, python 2.7, ubuntu-20.04

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-aiohttp
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-aiohttp-latest
 

--- a/.github/workflows/test-integration-ariadne.yml
+++ b/.github/workflows/test-integration-ariadne.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-ariadne
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-ariadne-latest
 

--- a/.github/workflows/test-integration-arq.yml
+++ b/.github/workflows/test-integration-arq.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-arq
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-arq-latest
 

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-asgi
 

--- a/.github/workflows/test-integration-asyncpg.yml
+++ b/.github/workflows/test-integration-asyncpg.yml
@@ -88,6 +88,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-asyncpg
 
@@ -157,6 +158,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-asyncpg-latest
 

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -69,6 +69,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-aws-lambda
 

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-beam
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-beam-latest
 

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-boto3
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-boto3-latest
 

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-bottle
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-bottle-latest
 

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-celery
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-celery-latest
 

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-chalice
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-chalice-latest
 

--- a/.github/workflows/test-integration-clickhouse_driver.yml
+++ b/.github/workflows/test-integration-clickhouse_driver.yml
@@ -69,6 +69,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-clickhouse-driver
 
@@ -119,6 +120,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-clickhouse-driver-latest
 

--- a/.github/workflows/test-integration-cloud_resource_context.yml
+++ b/.github/workflows/test-integration-cloud_resource_context.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-cloud-resource-context
 

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -88,6 +88,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-django
 
@@ -204,6 +205,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-django-latest
 

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-falcon
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-falcon-latest
 

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-fastapi
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-fastapi-latest
 

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-flask
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-flask-latest
 

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-gcp
 

--- a/.github/workflows/test-integration-gevent.yml
+++ b/.github/workflows/test-integration-gevent.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-gevent
 

--- a/.github/workflows/test-integration-gql.yml
+++ b/.github/workflows/test-integration-gql.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-gql
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-gql-latest
 

--- a/.github/workflows/test-integration-graphene.yml
+++ b/.github/workflows/test-integration-graphene.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-graphene
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-graphene-latest
 

--- a/.github/workflows/test-integration-grpc.yml
+++ b/.github/workflows/test-integration-grpc.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-grpc
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-grpc-latest
 

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-httpx
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-httpx-latest
 

--- a/.github/workflows/test-integration-huey.yml
+++ b/.github/workflows/test-integration-huey.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-huey
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-huey-latest
 

--- a/.github/workflows/test-integration-loguru.yml
+++ b/.github/workflows/test-integration-loguru.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-loguru
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-loguru-latest
 

--- a/.github/workflows/test-integration-opentelemetry.yml
+++ b/.github/workflows/test-integration-opentelemetry.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-opentelemetry
 

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-pure-eval
 

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-pymongo
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-pymongo-latest
 

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-pyramid
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-pyramid-latest
 

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-quart
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-quart-latest
 

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-redis
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-redis-latest
 

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-rediscluster
 

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-requests
 

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-rq
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-rq-latest
 

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-sanic
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-sanic-latest
 

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-sqlalchemy
 
@@ -143,6 +144,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-sqlalchemy-latest
 

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-starlette
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-starlette-latest
 

--- a/.github/workflows/test-integration-starlite.yml
+++ b/.github/workflows/test-integration-starlite.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-starlite
 

--- a/.github/workflows/test-integration-strawberry.yml
+++ b/.github/workflows/test-integration-strawberry.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-strawberry
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-strawberry-latest
 

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-tornado
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-tornado-latest
 

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-trytond
 
@@ -115,6 +116,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: integration-trytond-latest
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ coverage:
       default:
         target: auto  # auto compares coverage to the previous base commit
         threshold: 10%  # this allows a 10% drop from the previous base commit coverage
-        informational: true
+        informational: false
 ignore:
   - "tests"
   - "sentry_sdk/_types.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ coverage:
       default:
         target: auto  # auto compares coverage to the previous base commit
         threshold: 10%  # this allows a 10% drop from the previous base commit coverage
-        informational: false
+        informational: true
 ignore:
   - "tests"
   - "sentry_sdk/_types.py"

--- a/scripts/split-tox-gh-actions/ci-yaml-test-latest-snippet.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml-test-latest-snippet.txt
@@ -36,5 +36,6 @@
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: yaml-test-latest

--- a/scripts/split-tox-gh-actions/ci-yaml-test-snippet.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml-test-snippet.txt
@@ -36,5 +36,6 @@
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          url: https://ingest.codecov.io
           files: coverage.xml
           flags: yaml-test


### PR DESCRIPTION
Adds an upload URL to the Codecov github action. This routes all uploads through Codecov's new Shelter based ingest system.